### PR TITLE
chore: change api path

### DIFF
--- a/src/emqx_acl_mnesia_api.erl
+++ b/src/emqx_acl_mnesia_api.erl
@@ -24,28 +24,28 @@
 
 -rest_api(#{name   => list_emqx_acl,
             method => 'GET',
-            path   => "/emqx_acl",
+            path   => "/mqtt_acl",
             func   => list,
             descr  => "List available mnesia in the cluster"
            }).
 
 -rest_api(#{name   => lookup_emqx_acl,
             method => 'GET',
-            path   => "/emqx_acl/:bin:login",
+            path   => "/mqtt_acl/:bin:login",
             func   => lookup,
             descr  => "Lookup mnesia in the cluster"
            }).
 
 -rest_api(#{name   => add_emqx_acl,
             method => 'POST',
-            path   => "/emqx_acl",
+            path   => "/mqtt_acl",
             func   => add,
             descr  => "Add mnesia in the cluster"
            }).
 
 -rest_api(#{name   => delete_emqx_acl,
             method => 'DELETE',
-            path   => "/emqx_acl/:bin:login/:bin:topic",
+            path   => "/mqtt_acl/:bin:login/:bin:topic",
             func   => delete,
             descr  => "Delete mnesia in the cluster"
            }).

--- a/src/emqx_auth_mnesia_api.erl
+++ b/src/emqx_auth_mnesia_api.erl
@@ -24,35 +24,35 @@
 
 -rest_api(#{name   => list_emqx_user,
             method => 'GET',
-            path   => "/auth_user",
+            path   => "/mqtt_user",
             func   => list,
             descr  => "List available mnesia in the cluster"
            }).
 
 -rest_api(#{name   => lookup_emqx_user,
             method => 'GET',
-            path   => "/auth_user/:bin:login",
+            path   => "/mqtt_user/:bin:login",
             func   => lookup,
             descr  => "Lookup mnesia in the cluster"
            }).
 
 -rest_api(#{name   => add_emqx_user,
             method => 'POST',
-            path   => "/auth_user",
+            path   => "/mqtt_user",
             func   => add,
             descr  => "Add mnesia in the cluster"
            }).
 
 -rest_api(#{name   => update_emqx_user,
             method => 'PUT',
-            path   => "/auth_user/:bin:login",
+            path   => "/mqtt_user/:bin:login",
             func   => update,
             descr  => "Update mnesia in the cluster"
            }).
 
 -rest_api(#{name   => delete_emqx_user,
             method => 'DELETE',
-            path   => "/auth_user/:bin:login",
+            path   => "/mqtt_user/:bin:login",
             func   => delete,
             descr  => "Delete mnesia in the cluster"
            }).

--- a/test/emqx_acl_mnesia_SUITE.erl
+++ b/test/emqx_acl_mnesia_SUITE.erl
@@ -238,7 +238,7 @@ request_http_rest_delete(Login, Topic) ->
 uri() -> uri([]).
 uri(Parts) when is_list(Parts) ->
     NParts = [b2l(E) || E <- Parts],
-    ?HOST ++ filename:join([?BASE_PATH, ?API_VERSION, "emqx_acl"| NParts]).
+    ?HOST ++ filename:join([?BASE_PATH, ?API_VERSION, "mqtt_acl"| NParts]).
 
 %% @private
 b2l(B) when is_binary(B) ->

--- a/test/emqx_auth_mnesia_SUITE.erl
+++ b/test/emqx_auth_mnesia_SUITE.erl
@@ -209,7 +209,7 @@ request_http_rest_delete(Login) ->
 uri() -> uri([]).
 uri(Parts) when is_list(Parts) ->
     NParts = [b2l(E) || E <- Parts],
-    ?HOST ++ filename:join([?BASE_PATH, ?API_VERSION, "auth_user"| NParts]).
+    ?HOST ++ filename:join([?BASE_PATH, ?API_VERSION, "mqtt_user"| NParts]).
 
 %% @private
 b2l(B) when is_binary(B) ->


### PR DESCRIPTION
BROKEN-CHANGES:

To unify the path names of HTTP API  and the command name of CLI, We modify the HTTP API path name:
```
emqx_auth -> mqtt_auth
emqx_acl -> mqtt_acl
```