### PR TITLE
fix: Typo in mnesia table name

### DIFF
--- a/src/emqx_acl_mnesia.erl
+++ b/src/emqx_acl_mnesia.erl
@@ -31,7 +31,7 @@ init() ->
             {disc_copies, [node()]},
             {attributes, record_info(fields, emqx_acl)},
             {storage_properties, [{ets, [{read_concurrency, true}]}]}]),
-    ok = ekka_mnesia:copy_table(emqx_user, disc_copies).
+    ok = ekka_mnesia:copy_table(emqx_acl, disc_copies).
 
 -spec(register_metrics() -> ok).
 register_metrics() ->


### PR DESCRIPTION
As a result, the table is not copied to nodes joined cluster.
This has been fixed in enterprise branch long ago,
but for some reason it was not backported to opensource.